### PR TITLE
Add Debian support.

### DIFF
--- a/manifests/data.pp
+++ b/manifests/data.pp
@@ -24,6 +24,24 @@ class haproxy::data {
                                     'maxconn' => '8000'
                                   }
     }
+    Debian: {
+      $haproxy_global_options   = { 'log'     => "127.0.0.1 local0",
+                                    'chroot'  => '/var/lib/haproxy',
+                                    'pidfile' => '/var/run/haproxy.pid',
+                                    'maxconn' => '4000',
+                                    'user'    => 'haproxy',
+                                    'group'   => 'haproxy',
+                                    'daemon'  => '',
+                                    'stats'   => 'socket /var/lib/haproxy/stats'
+                                  }
+      $haproxy_defaults_options = { 'log'     => 'global',
+                                    'stats'   => 'enable',
+                                    'option'  => 'redispatch',
+                                    'retries' => '3',
+                                    'timeout' => ['http-request 10s', 'queue 1m', 'connect 10s', 'client 1m', 'server 1m', 'check 10s'],
+                                    'maxconn' => '8000'
+                                  }
+    }
     default: { fail("The $::operatingsystem operating system is not supported with the haproxy module") }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,6 +92,19 @@ class haproxy (
       order   => '10',
       content => template('haproxy/haproxy-base.cfg.erb'),
     }
+
+    if ($::operatingsystem == 'Ubuntu') {
+      file { '/etc/default/haproxy':
+        content => 'ENABLED=1',
+        require => Package['haproxy']
+      }
+    }
+
+    file { '/var/lib/haproxy':
+      ensure => directory,
+      before => Service['haproxy'],
+    }
+
   }
 
   service { 'haproxy':


### PR DESCRIPTION
This pull requests performs the minimum amount of effort to add
Debian support.

Adds Debian defaults (which were made to be as similar as possible
to the Redhat defaults)

Adds two Debian specific resources to the haproxy class
- a defaults file to ensure the service is started
- creates the /var/lib/haproxy directory so that the
  configuration can be as similar to Redhat as possible.y
