### PR TITLE
Error message should display the value being tested.

### DIFF
--- a/manifests/data.pp
+++ b/manifests/data.pp
@@ -24,6 +24,6 @@ class haproxy::data {
                                     'maxconn' => '8000'
                                   }
     }
-    default: { fail("The $::operatingsystem operating system is not supported with the haproxy module") }
+    default: { fail("The $::osfamily operating system is not supported with the haproxy module") }
   }
 }


### PR DESCRIPTION
The haproxy::data class incorrectly reports that the operatingsystem is not compatible, when the test is actually against the osfamily. 
